### PR TITLE
Fixes: v0.3.2

### DIFF
--- a/addons/scene_manager/SceneManager.gd
+++ b/addons/scene_manager/SceneManager.gd
@@ -59,10 +59,10 @@ func _ready():
 func _set_singleton_entities():
 	singleton_entities = {}
 	var entities = _current_scene.get_tree().get_nodes_in_group(
-		SceneManagerPlugin.get_singleton_group()
+		SceneManagerConstants.SINGLETON_GROUP_NAME
 	)
 	for entity in entities:
-		var has_entity_name = entity.has_meta(SceneManagerPlugin.get_singleton_meta_name())
+		var has_entity_name = entity.has_meta(SceneManagerConstants.SINGLETON_META_NAME)
 		assert(
 			has_entity_name,
 			(
@@ -70,7 +70,7 @@ func _set_singleton_entities():
 				% entity.name
 			)
 		)
-		var entity_name = entity.get_meta(SceneManagerPlugin.get_singleton_meta_name())
+		var entity_name = entity.get_meta(SceneManagerConstants.SINGLETON_META_NAME)
 		assert(
 			not singleton_entities.has(entity_name),
 			(

--- a/addons/scene_manager/SceneManager.gd
+++ b/addons/scene_manager/SceneManager.gd
@@ -62,43 +62,43 @@ func _set_singleton_entities():
 		SceneManagerPlugin.get_singleton_group()
 	)
 	for entity in entities:
-		if entity.has_meta(SceneManagerPlugin.get_singleton_meta_name()):
-			var entity_name = entity.get_meta(SceneManagerPlugin.get_singleton_meta_name())
-			if singleton_entities.has(entity_name):
-				push_error(
-					(
-						"The entity name %s is already being used more than once! Please check that your entity name is unique within the scene."
-						% entity_name
-					)
-				)
-			singleton_entities[entity_name] = entity
-		else:
-			push_error(
-				(
-					"The node %s was set as a singleton entity, but no entity name was provided."
-					% entity.name
-				)
-			)
-
-
-func get_entity(entity_name: String):
-	if not singleton_entities.has(entity_name):
-		push_error(
+		var has_entity_name = entity.has_meta(SceneManagerPlugin.get_singleton_meta_name())
+		assert(
+			has_entity_name,
 			(
-				"Entity %s is not set as a singleton entity. Please define it in the editor."
+				"The node %s was set as a singleton entity, but no entity name was provided."
+				% entity.name
+			)
+		)
+		var entity_name = entity.get_meta(SceneManagerPlugin.get_singleton_meta_name())
+		assert(
+			not singleton_entities.has(entity_name),
+			(
+				"The entity name %s is already being used more than once! Please check that your entity name is unique within the scene."
 				% entity_name
 			)
 		)
+		singleton_entities[entity_name] = entity
+
+
+func get_entity(entity_name: String):
+	assert(
+		singleton_entities.has(entity_name),
+		"Entity %s is not set as a singleton entity. Please define it in the editor." % entity_name
+	)
 	return singleton_entities[entity_name]
 
 
 func _load_pattern(pattern):
+	assert(
+		pattern is Texture or pattern is String,
+		"Pattern %s is not a valid Texture, absolute path, or built-in texture." % pattern
+	)
+
 	if pattern is String:
 		if pattern.is_abs_path():
 			return load(pattern)
 		return load("res://addons/scene_manager/shader_patterns/%s.png" % pattern)
-	elif not pattern is Texture:
-		push_error("Pattern %s is not a valid Texture or path." % pattern)
 	return pattern
 
 

--- a/addons/scene_manager/SceneManagerConstants.gd
+++ b/addons/scene_manager/SceneManagerConstants.gd
@@ -1,0 +1,5 @@
+extends Object
+class_name SceneManagerConstants
+
+const SINGLETON_GROUP_NAME = "scene_manager_entity_nodes"
+const SINGLETON_META_NAME = "entity_name"

--- a/addons/scene_manager/SceneManagerPlugin.gd
+++ b/addons/scene_manager/SceneManagerPlugin.gd
@@ -1,12 +1,5 @@
 tool
 extends EditorPlugin
-class_name SceneManagerPlugin
-
-static func get_singleton_group():
-	return "scene_manager_entity_nodes"
-static func get_singleton_meta_name():
-	return "entity_name"
-
 var _inspector_plugin
 
 

--- a/addons/scene_manager/SingletonCheckProperty.gd
+++ b/addons/scene_manager/SingletonCheckProperty.gd
@@ -2,7 +2,7 @@ extends EditorProperty
 
 var checkbox = CheckBox.new()
 var edited_control = null
-var group_name = SceneManagerPlugin.get_singleton_group()
+var group_name = SceneManagerConstants.SINGLETON_GROUP_NAME
 
 
 func _ready():

--- a/addons/scene_manager/SingletonNameProperty.gd
+++ b/addons/scene_manager/SingletonNameProperty.gd
@@ -2,8 +2,8 @@ extends EditorProperty
 
 var line_edit = LineEdit.new()
 var edited_control = null
-var meta_name = SceneManagerPlugin.get_singleton_meta_name()
-var group_name = SceneManagerPlugin.get_singleton_group()
+var meta_name = SceneManagerConstants.SINGLETON_META_NAME
+var group_name = SceneManagerConstants.SINGLETON_GROUP_NAME
 
 
 func _ready():

--- a/addons/scene_manager/SingletonNameProperty.gd
+++ b/addons/scene_manager/SingletonNameProperty.gd
@@ -3,6 +3,7 @@ extends EditorProperty
 var line_edit = LineEdit.new()
 var edited_control = null
 var meta_name = SceneManagerPlugin.get_singleton_meta_name()
+var group_name = SceneManagerPlugin.get_singleton_group()
 
 
 func _ready():
@@ -20,7 +21,7 @@ func _physics_process(_delta):
 	if edited_control:
 		draw_red = (
 			not edited_control.has_meta(meta_name)
-			and edited_control.is_in_group(meta_name)
+			and edited_control.is_in_group(group_name)
 		)
 
 

--- a/project.godot
+++ b/project.godot
@@ -9,12 +9,18 @@
 config_version=4
 
 _global_script_classes=[ {
+"base": "Object",
+"class": "SceneManagerConstants",
+"language": "GDScript",
+"path": "res://addons/scene_manager/SceneManagerConstants.gd"
+}, {
 "base": "EditorPlugin",
 "class": "SceneManagerPlugin",
 "language": "GDScript",
 "path": "res://addons/scene_manager/SceneManagerPlugin.gd"
 } ]
 _global_script_class_icons={
+"SceneManagerConstants": "",
 "SceneManagerPlugin": ""
 }
 


### PR DESCRIPTION
Fixes #5 

Fixes in this PR:
- Correct error color for singleton entity without name
- Throw actual errors instead of pushing warnings
- Using PluginEditor on runtime crashes builds (Add `SceneManagerConstants` for runtime reading)